### PR TITLE
Skip splash screen on any button press

### DIFF
--- a/datadir/WSPLASH.SRC
+++ b/datadir/WSPLASH.SRC
@@ -19,6 +19,18 @@ Refresh()
   self = FindSelf()
 
 
+  // Skip splash on any button press.
+  if(mode < 11)
+    i = 0
+    while(i < 256)
+      if(SystemGet(SYS_KEYPRESSED, i, 0))
+        // Go to mode=11, which is the final state of the splash screen.
+        mode = 11
+        timer = 0
+        i = 256
+      i++
+
+
   // Set the scaling to large...
   SystemSet(SYS_WINDOWSCALE, 0, 0, 2048)
 


### PR DESCRIPTION
This patch allows the user to skip the splash screen by pressing any button.

Having to go through the splash screen on every startup is annoying when you restart the game very often, whether for playing or debugging.