### PR TITLE
Play splash screen music only once, without looping

### DIFF
--- a/datadir/WSPLASH.SRC
+++ b/datadir/WSPLASH.SRC
@@ -8,7 +8,7 @@ Spawn()
   mode = 0
   timer = 0
   SystemSet(SYS_CURSORDRAW, 0, 0, FALSE)
-  PlayMusic("FILE:GOODNITE.MUS", FileReadByte("FILE:GOODNITE.MUS", 26), MUSIC_PLAY)
+  PlayMusic("FILE:GOODNITE.MUS", FileReadByte("FILE:GOODNITE.MUS", 26), MUSIC_ONCE)
 
 
 //-----------------------------------------------------------------------
@@ -24,6 +24,9 @@ Refresh()
     i = 0
     while(i < 256)
       if(SystemGet(SYS_KEYPRESSED, i, 0))
+        // End splash screen music instantly when skipping it by button press.
+        StopMusic()
+
         // Go to mode=11, which is the final state of the splash screen.
         mode = 11
         timer = 0
@@ -108,7 +111,7 @@ Refresh()
     timer = timer + SystemGet(SYS_MAINFRAMESKIP, 0, 0) * 3
   if(mode == 5)
     mode = 6
-    PlayMusic("FILE:EVILNITE.MUS", FileReadByte("FILE:EVILNITE.MUS", 26), MUSIC_PLAY)
+    PlayMusic("FILE:EVILNITE.MUS", FileReadByte("FILE:EVILNITE.MUS", 26), MUSIC_ONCE)
   if(mode == 6)
     WindowMegaImage(-16.0,-2.0,  0.0,-2.0,  0.0,2.0,  -16.0,2.0  ,0.01,0.0,  1.0,1.0,  WHITE, ALPHA_NONE, "FILE:TITLEL.RGB")
     WindowMegaImage(0.0,-2.0,  16.0,-2.0,  16.0,2.0,  0.0,2.0  ,0.0,0.0,  0.99,1.0,  WHITE, ALPHA_NONE, "FILE:TITLER.RGB")


### PR DESCRIPTION
My memory tells me that the original main game menu had no background music. The splash screen music persisted to it, but did not loop, and so it all fell silent within a short time.

However, in a cursory search over this codebase's git history, I couldn't find when this behavior was introduced to the codebase. 0be4af6db88a4a1760d7cd7d479c861c3751a306 already contains `MUSIC_PLAY` instead of `MUSIC_ONCE`. 2b17142074c3c9661eb33b6829c96768a49b8861 modifies the splash screen, so perhaps the culprit could be around there, or perhaps it happened happened before the datadir was unpacked. Or perhaps my memory is wrong.

Nevertheless, this soundtrack is not particularly pleasant to listen to anyway, and it ceases if you go to a submenu, so in my opinion it's better to not have it loop through the main menu anyway.

Closes https://github.com/soulfu-dev/soulfu/issues/34